### PR TITLE
decrease CppBase rigidity

### DIFF
--- a/pymoskito/binding_modules.py
+++ b/pymoskito/binding_modules.py
@@ -53,6 +53,7 @@ class CppBase:
                  module_name=None,
                  binding_source=None,
                  additional_sources=None,
+                 binding_class_name=None,
                  additional_lib=None):
         self._logger = logging.getLogger(self.__class__.__name__)
 
@@ -74,9 +75,15 @@ class CppBase:
             raise BindingException(message)
 
         if binding_source is None:
-            message = "Instantiation of binding class without binding_source is not allowed!"
-            self._logger.error(message)
-            raise BindingException(message)
+            if binding_class_name is not None:
+                binding_source = binding_class_name + ".cpp"
+                module_source = module_name + ".cpp"
+                additional_sources = additional_sources.append(module_source) if additional_sources else [module_source]
+                self._logger.warn("Use of binding_class_name is deprecated. Please migrate to binding_source")
+            else:
+                message = "Instantiation of binding class without binding_source is not allowed!"
+                self._logger.error(message)
+                raise BindingException(message)
 
         self.module_path = Path(module_path)
         self.module_binding = self.module_path / binding_source

--- a/pymoskito/binding_modules.py
+++ b/pymoskito/binding_modules.py
@@ -117,7 +117,7 @@ class CppBase:
             return False
 
         if not self.cmake_lists_path.is_file():
-            self._logger.warning("CMakeLists.txt not found in module path.")
+            self._logger.info("CMakeLists.txt not found in module path.")
             self._logger.info("Generating new CMake config.")
             self.create_cmake_lists()
 

--- a/pymoskito/binding_modules.py
+++ b/pymoskito/binding_modules.py
@@ -62,17 +62,15 @@ class CppBase:
             self.sfx = '.so'
 
         if module_name is None:
-            self._logger.error("Instantiation of binding class without"
-                               " module_name is not allowed!")
-            raise BindingException("Instantiation of binding class without"
-                                   " module_name is not allowed!")
+            message = "Instantiation of binding class without module_name is not allowed!"
+            self._logger.error(message)
+            raise BindingException(message)
         self.module_name = module_name
 
         if module_path is None:
-            self._logger.error("Instantiation of binding class without"
-                               " module_path is not allowed!")
-            raise BindingException("Instantiation of binding class without"
-                                   " module_path is not allowed!")
+            message = "Instantiation of binding class without module_path is not allowed!"
+            self._logger.error(message)
+            raise BindingException(message)
 
         self.module_path = Path(module_path)
         self.module_stem = self.module_path / self.module_name
@@ -88,10 +86,9 @@ class CppBase:
             self.additional_lib = additional_lib
 
         if binding_class_name is None:
-            self._logger.error("Instantiation of binding class without"
-                               " binding_class_name is not allowed!")
-            raise BindingException("Instantiation of binding class without"
-                                   " binding_class_name is not allowed!")
+            message = "Instantiation of binding class without binding_class_name is not allowed!"
+            self._logger.error(message)
+            raise BindingException(message)
         self.binding_class_name = binding_class_name
 
         if self.create_binding_config():
@@ -188,18 +185,18 @@ class CppBase:
             self.module_name,
             self.sfx
         )
-        
+
         config_target_line = lambda lib : "\ttarget_link_libraries({} ${{{}}}".format(
-            self.module_name, lib, 
+            self.module_name, lib,
         )
-        
+
         config_target_libs = ""
         if self.additional_lib:
             for key, _ in self.additional_lib.items():
                 config_target_libs += " {}".format(key)
         config_target_libs += ")\n"
 
-        
+
         config_line += "if(WIN32 AND MSVC)\n"
         config_line += config_target_line("Python_LIBRARY_RELEASE")
         config_line += config_target_libs
@@ -207,7 +204,7 @@ class CppBase:
         config_line += config_target_line("PYTHON_LIBRARIES")
         config_line += config_target_libs
         config_line += "endif()\n"
-        
+
         config_line += "install(FILES {}/{} DESTINATION {})".format(
             BUILD_DIR,
             self.module_name + self.sfx,
@@ -234,8 +231,9 @@ class CppBase:
         result = subprocess.run(cmd, cwd=self.module_path)
 
         if result.returncode != 0:
-            self._logger.error("Generation of binding config failed.")
-            raise BindingException("Generation of binding config failed.")
+            message = "Generation of binding config failed."
+            self._logger.error(message)
+            raise BindingException(message)
 
     def build_binding(self):
         # build
@@ -246,8 +244,9 @@ class CppBase:
         result = subprocess.run(cmd, cwd=self.module_path)
 
         if result.returncode != 0:
-            self._logger.error("Build failed!")
-            raise BindingException("Build failed!")
+            message = "Build failed!"
+            self._logger.error(message)
+            raise BindingException(message)
 
     def install_binding(self):
         # generate config
@@ -256,10 +255,10 @@ class CppBase:
         else:
             cmd = ['cmake', '--install', BUILD_DIR]
         result = subprocess.run(cmd, cwd=self.module_path)
-
         if result.returncode != 0:
-            self._logger.error("Installation of bindings failed.")
-            raise BindingException("Installation of bindings failed.")
+            message = "Installation of bindings failed."
+            self._logger.error(message)
+            raise BindingException(message)
 
     def get_class_from_module(self):
         try:


### PR DESCRIPTION
This series of commits starts out with some general improvements, then improves `CppBase`s flexibility, and finally reenables current usage of the class.

This could still be simplified further, all the while increasing flexibility, but I expect this to be a nice middle ground between still guiding unknowledgeable users, while not hindering others.

I could also update the pymoskito examples to use the undeprecated arguments of `CppBase` if this is desired